### PR TITLE
Snapshot build variants

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Base image can be specified by --build-arg IMAGE_ARCH= ; defaults to debian:bullseye
-ARG IMAGE_ARCH=debian:bullseye
+ARG DEBIAN=bullseye
+ARG IMAGE_ARCH=debian:${DEBIAN}
 FROM ${IMAGE_ARCH}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG VERSION=2.4.15
 ENV VERSION ${VERSION}
 ARG TARGETPLATFORM
-ARG DEBIAN=bullseye
 ARG BTRFS
 ARG ZFS
 
@@ -17,7 +17,7 @@ RUN URL=https://hndl.urbackup.org/Server/${VERSION} && \
          "linux/amd64")  URL=$URL/debian/${DEBIAN}/urbackup-server_${VERSION}_amd64.deb  ;; \
          "linux/arm64")  URL=$URL/urbackup-server_${VERSION}_arm64.deb  ;; \
          "linux/arm/v7") URL=$URL/urbackup-server_${VERSION}_armhf.deb  ;; \
-         "linux/386")    URL=$URL/debian/${DEBIAN}/urbackup-server_${VERSION}_i386.deb   ;; \
+         "linux/i386")   URL=$URL/debian/${DEBIAN}/urbackup-server_${VERSION}_i386.deb   ;; \
     esac \
     && dry="http://deb.debian.org/debian ${DEBIAN}-backports main contrib" \
     && echo "deb $dry\ndeb-src $dry" >/etc/apt/sources.list.d/${DEBIAN}-backports.list \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,43 @@
-# Base image can be specified by --build-arg IMAGE_ARCH= ; defaults to debian:buster
-ARG IMAGE_ARCH=debian:buster
+# Base image can be specified by --build-arg IMAGE_ARCH= ; defaults to debian:bullseye
+ARG IMAGE_ARCH=debian:bullseye
 FROM ${IMAGE_ARCH}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ARG VERSION=2.4.15
 ENV VERSION ${VERSION}
 ARG TARGETPLATFORM
+ARG DEBIAN=bullseye
+ARG BTRFS
+ARG ZFS
 
 COPY entrypoint.sh /usr/bin/
 
-RUN case ${TARGETPLATFORM} in \
-         "linux/amd64")  URL=https://hndl.urbackup.org/Server/${VERSION}/debian/buster/urbackup-server_${VERSION}_amd64.deb  ;; \
-         "linux/arm64")  URL=https://hndl.urbackup.org/Server/${VERSION}/urbackup-server_${VERSION}_arm64.deb  ;; \
-         "linux/arm/v7") URL=https://hndl.urbackup.org/Server/${VERSION}/urbackup-server_${VERSION}_armhf.deb  ;; \
-         "linux/386")    URL=https://hndl.urbackup.org/Server/${VERSION}/debian/buster/urbackup-server_${VERSION}_i386.deb   ;; \
+RUN URL=https://hndl.urbackup.org/Server/${VERSION} && \
+    case ${TARGETPLATFORM} in \
+         "linux/amd64")  URL=$URL/debian/${DEBIAN}/urbackup-server_${VERSION}_amd64.deb  ;; \
+         "linux/arm64")  URL=$URL/urbackup-server_${VERSION}_arm64.deb  ;; \
+         "linux/arm/v7") URL=$URL/urbackup-server_${VERSION}_armhf.deb  ;; \
+         "linux/386")    URL=$URL/debian/${DEBIAN}/urbackup-server_${VERSION}_i386.deb   ;; \
     esac \
-        && apt-get update \
-        && apt-get install -y wget \
-        && wget -q "$URL" -O /root/urbackup-server.deb \
-        && echo "urbackup-server urbackup/backuppath string /backups" | debconf-set-selections \
-        && apt-get install -y --no-install-recommends /root/urbackup-server.deb btrfs-tools \
-        && rm /root/urbackup-server.deb \
-        && apt-get clean \
-        && rm -rf /var/lib/apt/lists/*
-
-# Backing up www-folder
-RUN mkdir /web-backup && cp -R /usr/share/urbackup/* /web-backup
-# Making entrypoint-script executable
-RUN chmod +x /usr/bin/entrypoint.sh
+    && dry="http://deb.debian.org/debian ${DEBIAN}-backports main contrib" \
+    && echo "deb $dry\ndeb-src $dry" >/etc/apt/sources.list.d/${DEBIAN}-backports.list \
+    && apt-get update \
+    && apt-get install -y wget \
+    && wget -q "$URL" -O /root/urbackup-server.deb \
+    && apt-get remove -y wget \
+    && apt-get autoremove -y \
+    && echo "urbackup-server urbackup/backuppath string /backups" \
+            | debconf-set-selections \
+    && apt-get install -y --no-install-recommends \
+            /root/urbackup-server.deb \
+            ${BTRFS:+btrfs-progs} \
+            ${ZFS:+zfsutils-linux} \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+            /etc/apt/sources.list.d/${DEBIAN}-backports.list \
+            /root/urbackup-server.deb \
+    && cp -R /usr/share/urbackup /web-backup \
+    && chmod +x /usr/bin/entrypoint.sh
 
 EXPOSE 55413
 EXPOSE 55414

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-# Base image can be specified by --build-arg IMAGE_ARCH= ; defaults to debian:bullseye
 ARG DEBIAN=bullseye
-ARG IMAGE_ARCH=debian:${DEBIAN}
-FROM ${IMAGE_ARCH}
+FROM debian:${DEBIAN}
 
-ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN=bullseye
 ARG VERSION=2.4.15
-ENV VERSION ${VERSION}
 ARG TARGETPLATFORM
 ARG BTRFS
 ARG ZFS
@@ -21,6 +18,7 @@ RUN URL=https://hndl.urbackup.org/Server/${VERSION} && \
     esac \
     && dry="http://deb.debian.org/debian ${DEBIAN}-backports main contrib" \
     && echo "deb $dry\ndeb-src $dry" >/etc/apt/sources.list.d/${DEBIAN}-backports.list \
+    && export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
     && apt-get install -y wget \
     && wget -q "$URL" -O /root/urbackup-server.deb \

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ docker run -d \
 
 For BTRFS-Support add `--cap-add SYS_ADMIN` to the command above
 
+For ZFS support add `--device /dev/zfs` to the command above
+
 If you want to externally bind-mount the www-folder add `-v /path/to/wwwfolder:/usr/share/urbackup`
 
 ### Or via docker-compose (compatible with stacks in Portainer): 

--- a/build.sh
+++ b/build.sh
@@ -3,11 +3,36 @@ set -x
 
 # Accepted values for ARCH are amd64, armhf, arm64, i386
 ARCH=${1:-amd64}
-VERSION=${2:-2.4.13}
+VERSION=${2:-2.4.15}
+OPTS=${3}
+TAG=${VERSION}_${ARCH}
+
+case ${ARCH} in
+	"amd64")  IMAGE_ARCH="$BASE" ;;
+	"armhf")  IMAGE_ARCH="arm32v7/$BASE" ;;
+	"arm64")  IMAGE_ARCH="arm64v8/$BASE" ;;
+	"i386")   IMAGE_ARCH="i386/$BASE" ;;
+	*) echo "unrecognized architecture '$ARCH'" >>/dev/stderr ; exit 1 ;;
+esac
+
+if [[ " ${*} " =~ " btrfs " ]]; then
+	BTRFS=1
+	TAG=${TAG}_btrfs
+fi
+
+if [[ " ${*} " =~ " zfs " ]]; then
+	if [[ "$ARCH" != "amd64" ]]; then
+		echo "ZFS is only supported on amd64" ; exit 0
+	fi
+	ZFS=1
+	TAG=${TAG}_zfs
+fi
 
 docker build \
-              --build-arg ARCH=${ARCH} \
-              --build-arg VERSION=${VERSION} \
-              --build-arg IMAGE_ARCH=$([ "${ARCH}" == "armhf" ] && echo "arm32v7/debian:stretch" || ([ "${ARCH}" == "arm64" ] && echo "arm64v8/debian:stretch") || ([ "${BUILD_ARCH}" == "i386" ] && echo "i386/debian:stretch") || echo "debian:stretch") \
-              -t urbackup-server:${VERSION}_${ARCH} \
-              .
+		  --build-arg ARCH=${ARCH} \
+		  --build-arg VERSION=${VERSION} \
+		  --build-arg IMAGE_ARCH=${IMAGE_ARCH} \
+		  --build-arg BTRFS=${BTRFS} \
+		  --build-arg ZFS=${ZFS} \
+		  -t urbackup-server:${TAG} \
+		  .

--- a/build.sh
+++ b/build.sh
@@ -8,31 +8,31 @@ OPTS=${3}
 TAG=${VERSION}_${ARCH}
 
 case ${ARCH} in
-	"amd64")  IMAGE_ARCH="$BASE" ;;
-	"armhf")  IMAGE_ARCH="arm32v7/$BASE" ;;
-	"arm64")  IMAGE_ARCH="arm64v8/$BASE" ;;
-	"i386")   IMAGE_ARCH="i386/$BASE" ;;
-	*) echo "unrecognized architecture '$ARCH'" >>/dev/stderr ; exit 1 ;;
+    "amd64")  IMAGE_ARCH="$BASE" ;;
+    "armhf")  IMAGE_ARCH="arm32v7/$BASE" ;;
+    "arm64")  IMAGE_ARCH="arm64v8/$BASE" ;;
+    "i386")   IMAGE_ARCH="i386/$BASE" ;;
+    *) echo "unrecognized architecture '$ARCH'" >>/dev/stderr ; exit 1 ;;
 esac
 
 if [[ " ${*} " =~ " btrfs " ]]; then
-	BTRFS=1
-	TAG=${TAG}_btrfs
+    BTRFS=1
+    TAG=${TAG}_btrfs
 fi
 
 if [[ " ${*} " =~ " zfs " ]]; then
-	if [[ "$ARCH" != "amd64" ]]; then
-		echo "ZFS is only supported on amd64" ; exit 0
-	fi
-	ZFS=1
-	TAG=${TAG}_zfs
+    if [[ "$ARCH" != "amd64" ]]; then
+        echo "ZFS is only supported on amd64" ; exit 0
+    fi
+    ZFS=1
+    TAG=${TAG}_zfs
 fi
 
 docker build \
-		  --build-arg ARCH=${ARCH} \
-		  --build-arg VERSION=${VERSION} \
-		  --build-arg IMAGE_ARCH=${IMAGE_ARCH} \
-		  --build-arg BTRFS=${BTRFS} \
-		  --build-arg ZFS=${ZFS} \
-		  -t urbackup-server:${TAG} \
-		  .
+          --build-arg ARCH=${ARCH} \
+          --build-arg VERSION=${VERSION} \
+          --build-arg IMAGE_ARCH=${IMAGE_ARCH} \
+          --build-arg BTRFS=${BTRFS} \
+          --build-arg ZFS=${ZFS} \
+          -t urbackup-server:${TAG} \
+          .


### PR DESCRIPTION
I needed an amd64 container with ZFS support for [TrueNAS SCALE](https://www.truenas.com/community/threads/urbackup-on-scale-custom-settings-install.98396/).

I ended up making btrfs and zfs both build-time options with separate tags.
```REPOSITORY              TAG                      IMAGE ID       CREATED         SIZE
urbackup-server         2.4.15_amd64             10607f884f1d   2 minutes ago   176MB
urbackup-server         2.4.15_amd64_btrfs       d0609c4e901c   2 minutes ago   180MB
urbackup-server         2.4.15_amd64_zfs         3007a1165778   2 minutes ago   209MB
urbackup-server         2.4.15_amd64_btrfs_zfs   46c2d67e80e1   3 minutes ago   214MB
ixsystems/zfs           latest                   738e70df4bce   3 days ago      2.02GB
uroni/urbackup-server   latest                   d8936920416d   2 months ago    177MB
```
I also bumped it from buster to bullseye, and flattened some unnecessary layers. Hopefully nothing too cavalier.

If you approve of the concept, I haven't tried to address CI/CD at all. That may need a tweak, as well.

Thanks for the great work!