### PR TITLE
Update CI and Docker Hub details

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,7 +37,7 @@ jobs:
         uses: peter-evans/dockerhub-description@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: uroni/urbackup-server
           short-description: ${{ github.event.repository.description }}
       -

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,6 +33,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
+        name: Update DockerHub description
+        uses: peter-evans/dockerhub-description@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: uroni/urbackup-server
+          short-description: ${{ github.event.repository.description }}
+      -
         name: Build and push baseline with btrfs support
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -33,7 +33,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
-        name: Build and push
+        name: Build and push baseline with btrfs support
         uses: docker/build-push-action@v3
         with:
           context: .
@@ -41,4 +41,17 @@ jobs:
           push: true
           build-args: |
             BTRFS=1
-          tags: uroni/urbackup-server:${{ steps.extract_branch.outputs.branch }}
+          tags:
+            - uroni/urbackup-server:${{ steps.extract_branch.outputs.branch }}-btrfs
+            - uroni/urbackup-server:${{ steps.extract_branch.outputs.branch }}
+      -
+        name: Build and push ZFS variant
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          build-args: |
+            ZFS=1
+          tags:
+            - uroni/urbackup-server:${{ steps.extract_branch.outputs.branch }}-zfs

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Extract branch name
         shell: bash
@@ -22,19 +22,19 @@ jobs:
         id: extract_branch
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       -
         name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/i386,linux/armhf

--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ services:
       # Uncomment the next line if you want to bind-mount the www-folder
       #- /path/to/wwwfolder:/usr/share/urbackup
     network_mode: "host"
-    # Activate the following two lines for BTRFS support
+    # Uncomment the following two lines if you're using BTRFS support
     #cap_add:
-    #  - SYS_ADMIN   
+    #  - SYS_ADMIN
+    # Uncomment the following two lines if you're using ZFS support
+    #devices:
+    #  - /dev/zfs:/dev/zfs
   
 ```              
 	     


### PR DESCRIPTION
Follow-up to #3: tweak the CI to publish an official ZFS variant, and to keep Docker Hub in sync with the local readme.

Note that the `short-description` would then follow that of the GitHub repo (currently "A multiarch docker image for a UrBackup server"). If you'd prefer to keep "Image to run UrBackup Server in Docker (https://urbackup.org)" you can supply that to the workflow as a static string.