### PR TITLE
Fix my Actions mistake from #4

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -49,9 +49,9 @@ jobs:
           push: true
           build-args: |
             BTRFS=1
-          tags:
-            - uroni/urbackup-server:${{ steps.extract_branch.outputs.branch }}-btrfs
-            - uroni/urbackup-server:${{ steps.extract_branch.outputs.branch }}
+          tags: |
+            uroni/urbackup-server:${{ steps.extract_branch.outputs.branch }}-btrfs
+            uroni/urbackup-server:${{ steps.extract_branch.outputs.branch }}
       -
         name: Build and push ZFS variant
         uses: docker/build-push-action@v3
@@ -61,5 +61,5 @@ jobs:
           push: true
           build-args: |
             ZFS=1
-          tags:
-            - uroni/urbackup-server:${{ steps.extract_branch.outputs.branch }}-zfs
+          tags: |
+            uroni/urbackup-server:${{ steps.extract_branch.outputs.branch }}-zfs


### PR DESCRIPTION
Per [investigation](https://github.com/uroni/urbackup-server-docker/pull/4#issuecomment-1264493772) this should get CI builds moving again (and complete the process of pushing ZFS-enabled builds and up-to-date readme guidance to Docker Hub with each subsequent commit).

In case this doesn't do it either, that same comment suggests fallback options. My bad.