### PR TITLE
fix: improve entrypoint to conditionally chown directories

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,9 @@ then
 else
 	groupmod -g 101 -o urbackup
 fi
-chown urbackup:urbackup /backups
-chown urbackup:urbackup /var/urbackup
+
+# Check if /backups and /var/urbackup is writable by urbackup user and conditionally chown
+su -s /bin/bash -c "test -w /backups" urbackup || chown urbackup:urbackup /backups
+su -s /bin/bash -c "test -w /var/urbackup" urbackup || chown urbackup:urbackup /var/urbackup
+
 exec urbackupsrv "$@"


### PR DESCRIPTION
This fix makes the entrypoint only attempt to chown if the directory is not writable to the 'urbackup' user. If the directory is not writable for root (example: rootless container, backup dir on host is NFS mounted and bind mounted into container) the chown will fail, preventing the container from running.