### PR TITLE
Set /etc/urbackup/dataset via ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ For BTRFS-Support add `--cap-add SYS_ADMIN` to the command above
 
 For ZFS support add `--device /dev/zfs` to the command above
 
+Add `-e ZFS_DATASET="your/dataset"` to the command above if you want to set the ZFS dataset via an ENV variable instead of mounting `/etc/urbackup/dataset`
+
 If you want to externally bind-mount the www-folder add `-v /path/to/wwwfolder:/usr/share/urbackup`
 
 ### Or via docker-compose (compatible with stacks in Portainer): 
@@ -43,6 +45,8 @@ services:
       - PUID=1000 # Enter the UID of the user who should own the files here
       - PGID=100  # Enter the GID of the user who should own the files here
       - TZ=Europe/Berlin # Enter your timezone
+      # Uncomment the next line if you want to set the ZFS dataset via an ENV variable instead of mounting /etc/urbackup/dataset
+      #- ZFS_DATASET="your/dataset"
     volumes:
       - /path/to/your/database/folder:/var/urbackup
       - /path/to/your/backup/folder:/backups

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For BTRFS-Support add `--cap-add SYS_ADMIN` to the command above
 
 For ZFS support add `--device /dev/zfs` to the command above
 
-Add `-e ZFS_DATASET="your/dataset"` to the command above if you want to set the ZFS dataset via an ENV variable instead of mounting `/etc/urbackup/dataset`
+Add `-e ZFS_IMAGE="tank/images"` and `-e ZFS_FILES="tank/files"` to the command above if you want to set the ZFS dataset via an ENV variable instead of mounting `/etc/urbackup/dataset*`
 
 If you want to externally bind-mount the www-folder add `-v /path/to/wwwfolder:/usr/share/urbackup`
 
@@ -45,8 +45,9 @@ services:
       - PUID=1000 # Enter the UID of the user who should own the files here
       - PGID=100  # Enter the GID of the user who should own the files here
       - TZ=Europe/Berlin # Enter your timezone
-      # Uncomment the next line if you want to set the ZFS dataset via an ENV variable instead of mounting /etc/urbackup/dataset
-      #- ZFS_DATASET="your/dataset"
+      # Uncomment the next lines if you want to set the ZFS datasets via ENV variables instead of mounting /etc/urbackup/dataset*
+      #- ZFS_IMAGE="tank/images"
+      #- ZFS_FILES="tank/files"
     volumes:
       - /path/to/your/database/folder:/var/urbackup
       - /path/to/your/backup/folder:/backups

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For BTRFS-Support add `--cap-add SYS_ADMIN` to the command above
 
 For ZFS support add `--device /dev/zfs` to the command above
 
-Add `-e ZFS_IMAGE="tank/images"` and `-e ZFS_FILES="tank/files"` to the command above if you want to set the ZFS dataset via an ENV variable instead of mounting `/etc/urbackup/dataset*`
+Add `-e ZFS_IMAGE=tank/images` and `-e ZFS_FILES=tank/files` to the command above if you want to set the ZFS dataset via an ENV variable instead of mounting `/etc/urbackup/dataset*`
 
 If you want to externally bind-mount the www-folder add `-v /path/to/wwwfolder:/usr/share/urbackup`
 
@@ -46,8 +46,8 @@ services:
       - PGID=100  # Enter the GID of the user who should own the files here
       - TZ=Europe/Berlin # Enter your timezone
       # Uncomment the next lines if you want to set the ZFS datasets via ENV variables instead of mounting /etc/urbackup/dataset*
-      #- ZFS_IMAGE="tank/images"
-      #- ZFS_FILES="tank/files"
+      #- ZFS_IMAGE=tank/images
+      #- ZFS_FILES=tank/files
     volumes:
       - /path/to/your/database/folder:/var/urbackup
       - /path/to/your/backup/folder:/backups

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,6 +4,10 @@ set -e
 cp -R /web-backup/* /usr/share/urbackup
 # Specifying backup-folder location
 echo "/backups" > /var/urbackup/backupfolder
+# Set ZFS dataset if ENV variable is not empty
+if [[ -v ZFS_DATASET ]]; then
+	echo "$ZFS_DATASET" > /etc/urbackup/dataset
+fi
 # Giving the user and group "urbackup" the provided UID/GID
 if [[ $PUID != "" ]]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,8 +5,11 @@ cp -R /web-backup/* /usr/share/urbackup
 # Specifying backup-folder location
 echo "/backups" > /var/urbackup/backupfolder
 # Set ZFS dataset if ENV variable is not empty
-if [[ -v ZFS_DATASET ]]; then
-	echo "$ZFS_DATASET" > /etc/urbackup/dataset
+if [[ -v ZFS_IMAGE ]]; then
+	echo "$ZFS_IMAGE" > /etc/urbackup/dataset
+fi
+if [[ -v ZFS_FILES ]]; then
+	echo "$ZFS_FILES" > /etc/urbackup/dataset_file
 fi
 # Giving the user and group "urbackup" the provided UID/GID
 if [[ $PUID != "" ]]


### PR DESCRIPTION
This PR adds the `$ZFS_DATASET` environment variable to allow setting the ZFS dataset to use. It doesn't affect any existing setups since `/etc/urbackup/dataset` is only written to if the ENV variable is set.
It also documents the use of this new ENV variable (commented out and unset by default).

Requiring the user to mount an already existing `/etc/urbackup/dataset` from the host system, especially since that's the only config file required to be created manually is not very elegant and also unnecessary if all that's being configured is a short string.