### PR TITLE
Mount ZFS datasets if environment variables are set

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,9 +20,11 @@ echo "/backups" > /var/urbackup/backupfolder
 # Set ZFS dataset if ENV variable is not empty
 if [[ -v ZFS_IMAGE ]]; then
 	echo "$ZFS_IMAGE" > /etc/urbackup/dataset
+	zfs mount -R "$ZFS_IMAGE"
 fi
 if [[ -v ZFS_FILES ]]; then
 	echo "$ZFS_FILES" > /etc/urbackup/dataset_file
+	zfs mount -R "$ZFS_FILES"
 fi
 # Giving the user and group "urbackup" the provided UID/GID
 if [[ $PUID != "" ]]


### PR DESCRIPTION
Make sure Dataset is mounted inside the container, see: https://forums.urbackup.org/t/urbackup-docker-zfs-error-opening-hashfile-code-2/15997/18

Marked as draft for now still needs a bit of testing.